### PR TITLE
Add Streamlit config and deployment notes

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,3 @@
+[server]
+headless = true
+enableCORS = false

--- a/README.md
+++ b/README.md
@@ -1,0 +1,24 @@
+# SLT Bug Analytics Dashboard
+
+This repository contains a Streamlit dashboard for analysing bug reports in the SLT Selfcare app.
+
+## Running Locally
+
+Install dependencies and start Streamlit:
+
+```bash
+pip install -r requirements.txt
+streamlit run src/dashboard/app.py
+```
+
+## Deployment Notes
+
+When deploying on platforms such as Streamlit Community Cloud or other headless environments, include the `.streamlit/config.toml` file in the repository. This file ensures the server runs in headless mode and disables CORS, which is required for remote access:
+
+```toml
+[server]
+headless = true
+enableCORS = false
+```
+
+Having these settings in place lets the dashboard start automatically without needing a browser on the server and prevents CORS issues when accessing the app.


### PR DESCRIPTION
## Summary
- configure Streamlit with a new `.streamlit/config.toml`
- add a README explaining how to run the app and why the config file helps deployment

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68479dc72c84832fbeef1360a8708aa6