### PR TITLE
Add scheduled pipeline workflow

### DIFF
--- a/.github/workflows/three_days_update.yml
+++ b/.github/workflows/three_days_update.yml
@@ -1,0 +1,21 @@
+name: Three Days Update
+
+on:
+  schedule:
+    - cron: '0 1 */3 * *'
+  workflow_dispatch:
+
+jobs:
+  run-pipeline:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run pipeline
+        run: python src/data_processing/run_pipeline.py

--- a/src/data_processing/run_pipeline.py
+++ b/src/data_processing/run_pipeline.py
@@ -7,14 +7,22 @@ def run_step(module_name, step_number, description):
     print(f"\n=== Step {step_number}: {description} ===")
     print(f"Running {module_name}...")
 
-    result = subprocess.run(['python', '-m', module_name],
-                            capture_output=True,
-                            text=True)
+    root_dir = Path(__file__).resolve().parents[2]
+    env = os.environ.copy()
+    env['PYTHONPATH'] = str(root_dir / 'src')
+
+    result = subprocess.run(
+        ['python', '-m', module_name],
+        capture_output=True,
+        text=True,
+        cwd=root_dir,
+        env=env
+    )
     
     if result.returncode == 0:
-        print(f"✓ {script_name} completed successfully")
+        print(f"✓ {module_name} completed successfully")
     else:
-        print(f"✗ Error running {script_name}")
+        print(f"✗ Error running {module_name}")
         print("Error output:")
         print(result.stderr)
         raise Exception(f"Pipeline failed at step {step_number}")


### PR DESCRIPTION
## Summary
- automate bug analytics pipeline every 3 days at 01:00 UTC
- fix run_pipeline NameError and set `PYTHONPATH`

## Testing
- `python -m py_compile src/data_processing/run_pipeline.py`
- `python src/data_processing/run_pipeline.py` *(fails at Step 1: ModuleNotFoundError for `google_play_scraper`)*

------
https://chatgpt.com/codex/tasks/task_e_68482aba0680832fbf714008170acc6b