### PR TITLE
Save pipeline CSV outputs

### DIFF
--- a/.github/workflows/three_days_update.yml
+++ b/.github/workflows/three_days_update.yml
@@ -19,3 +19,22 @@ jobs:
           pip install -r requirements.txt
       - name: Run pipeline
         run: python src/data_processing/run_pipeline.py
+
+      - name: Commit CSV outputs
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/*.csv
+          if git diff --cached --quiet; then
+            echo "No CSV changes to commit"
+          else
+            git commit -m "Update data CSV files"
+            git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+            git push origin HEAD:${{ github.ref }}
+          fi
+
+      - name: Upload CSV outputs
+        uses: actions/upload-artifact@v3
+        with:
+          name: pipeline-csvs
+          path: data/*.csv


### PR DESCRIPTION
## Summary
- ensure generated CSV files are preserved after the scheduled pipeline
- upload the CSVs as artifacts and push them back to the repository

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68491bfa0e24832fa6fe520a5054316b