### PR TITLE
Fix artifact upload action version

### DIFF
--- a/.github/workflows/three_days_update.yml
+++ b/.github/workflows/three_days_update.yml
@@ -34,7 +34,7 @@ jobs:
           fi
 
       - name: Upload CSV outputs
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: pipeline-csvs
           path: data/*.csv


### PR DESCRIPTION
## Summary
- update the GitHub Actions workflow to use `actions/upload-artifact@v4`

## Testing
- `pytest -q`
