### PR TITLE
Add manual workflow for bug categories CSV

### DIFF
--- a/.github/workflows/bug_categories.yml
+++ b/.github/workflows/bug_categories.yml
@@ -1,0 +1,38 @@
+name: Run bug categories script
+
+on:
+  workflow_dispatch:
+
+jobs:
+  run-script:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+      - name: Run bug categories
+        run: python src/data_processing/bug__categories.py
+
+      - name: Commit CSV output
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add data/categorized_bugs.csv
+          if git diff --cached --quiet; then
+            echo "No CSV changes to commit"
+          else
+            git commit -m "Update categorized bugs CSV"
+            git remote set-url origin "https://x-access-token:${{ secrets.GITHUB_TOKEN }}@github.com/${{ github.repository }}.git"
+            git push origin HEAD:${{ github.ref }}
+          fi
+
+      - name: Upload CSV output
+        uses: actions/upload-artifact@v4
+        with:
+          name: categorized-bugs-csv
+          path: data/categorized_bugs.csv


### PR DESCRIPTION
## Summary
- run `bug__categories.py` with manual workflow
- commit categorized CSV output
- upload the CSV as an artifact
