### PR TITLE
Add email notifier script

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,8 @@
 # OpenAI API Key (Required for developer_summary.py)
 OPENAI_API_KEY=
+
+# Email credentials for bug_email_notifier.py
+# EMAIL_USER=you@example.com
+# EMAIL_PASS=app_password
+# Optional separate recipient
+# EMAIL_TO=

--- a/README.md
+++ b/README.md
@@ -12,11 +12,14 @@ streamlit run src/dashboard/app.py
 ```
 
 The application can load environment variables from a `.env` file. The
-processing scripts use `OPENAI_API_KEY` for accessing the OpenAI API, so a
-minimal `.env` might look like:
+processing scripts use `OPENAI_API_KEY` for accessing the OpenAI API and
+`bug_email_notifier.py` requires email credentials. A minimal `.env` might look like:
 
 ```env
 OPENAI_API_KEY=
+# EMAIL_USER=you@example.com
+# EMAIL_PASS=app_password
+# EMAIL_TO=
 ```
 
 ## Deployment Notes

--- a/src/dashboard/app.py
+++ b/src/dashboard/app.py
@@ -6,6 +6,7 @@ import plotly.express as px
 from datetime import datetime
 import plotly.graph_objects as go
 from data_processing.non_bug import UserExperienceAnalyzer
+from dashboard.bug_email_notifier import main as send_bug_digest
 
 @st.cache_data
 def load_csv(path: str) -> pd.DataFrame:
@@ -516,3 +517,12 @@ try:
     )
 except Exception as e:
     st.sidebar.warning(f"Error setting up export: {str(e)}")
+
+# --- Manual Email Trigger ---
+st.sidebar.header("📧 Bug Digest Email")
+if st.sidebar.button("Send Email Now"):
+    try:
+        send_bug_digest()
+        st.sidebar.success("Bug digest sent")
+    except Exception as e:
+        st.sidebar.error(f"Failed to send email: {e}")

--- a/src/dashboard/bug_email_notifier.py
+++ b/src/dashboard/bug_email_notifier.py
@@ -1,0 +1,102 @@
+import os
+import pandas as pd
+import smtplib
+from email.mime.multipart import MIMEMultipart
+from email.mime.text import MIMEText
+
+try:
+    from dotenv import load_dotenv
+except Exception:  # pragma: no cover - python-dotenv optional
+    def load_dotenv(*_args, **_kwargs):
+        pass
+
+# Load environment variables if a .env file is present
+load_dotenv()
+
+DATA_PATH = os.path.join(os.path.dirname(__file__), '..', '..', 'data', 'categorized_bugs.csv')
+SENT_FILE = os.path.join(os.path.dirname(__file__), 'sent_tickets.txt')
+
+
+def load_bugs(path: str) -> pd.DataFrame:
+    df = pd.read_csv(path)
+    df = df.reset_index(drop=True)
+    df['TicketID'] = [f"BUG-{i+1001:04d}" for i in range(len(df))]
+    df['review_date'] = pd.to_datetime(df['review_date'], errors='coerce')
+    df = df.sort_values('review_date', ascending=False)
+    return df
+
+
+def load_sent_tickets(path: str) -> set[str]:
+    if not os.path.exists(path):
+        return set()
+    with open(path, 'r') as f:
+        return {line.strip() for line in f if line.strip()}
+
+
+def save_sent_tickets(tickets: set[str], path: str) -> None:
+    with open(path, 'w') as f:
+        for ticket in sorted(tickets):
+            f.write(f"{ticket}\n")
+
+
+def build_html_table(df: pd.DataFrame) -> str:
+    style = (
+        "<style>"
+        "table {border-collapse: collapse;width: 100%;}"\
+        "th, td {border: 1px solid #ddd;padding: 8px;text-align: left;}"\
+        "th {background-color: #f2f2f2;}"\
+        "</style>"
+    )
+    table = df.to_html(index=False, escape=False)
+    return f"{style}{table}"
+
+
+def send_email(subject: str, html_body: str) -> None:
+    user = os.environ.get('EMAIL_USER')
+    password = os.environ.get('EMAIL_PASS')
+    if not user or not password:
+        raise RuntimeError('EMAIL_USER and EMAIL_PASS environment variables are required')
+    receiver = os.environ.get('EMAIL_TO', user)
+
+    msg = MIMEMultipart('alternative')
+    msg['Subject'] = subject
+    msg['From'] = user
+    msg['To'] = receiver
+    msg.attach(MIMEText(html_body, 'html'))
+
+    with smtplib.SMTP_SSL('smtp.gmail.com', 465) as server:
+        server.login(user, password)
+        server.sendmail(user, receiver, msg.as_string())
+
+
+def main() -> None:
+    df = load_bugs(DATA_PATH)
+    sent = load_sent_tickets(SENT_FILE)
+
+    if not os.path.exists(SENT_FILE):
+        latest = df.head(10)
+        if not latest.empty:
+            html = build_html_table(latest[[
+                'TicketID', 'bug_category', 'appVersion', 'review_date', 'review_description'
+            ]])
+            send_email('🚀 Initial Bug Digest: Top 10 Recent Bug Tickets', html)
+        save_sent_tickets(set(df['TicketID']), SENT_FILE)
+        return
+
+    new_tickets = df[~df['TicketID'].isin(sent)]
+    if new_tickets.empty:
+        print('No new bug tickets to send.')
+        return
+
+    html = build_html_table(new_tickets[[
+        'TicketID', 'bug_category', 'appVersion', 'review_date', 'review_description'
+    ]])
+    subject = f"{len(new_tickets)} New Bug Tickets - SLT App"
+    send_email(subject, html)
+
+    sent.update(new_tickets['TicketID'])
+    save_sent_tickets(sent, SENT_FILE)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
## Summary
- add `bug_email_notifier.py` alongside dashboard app for sending new bug tickets over email
- add sidebar button in dashboard to manually send emails
- load environment variables from `.env` and document new email variables

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_684cf7a8cbd0832fbf205ab7e72e216a