### PR TITLE
Fix module path in bug email notifier

### DIFF
--- a/src/dashboard/bug_email_notifier.py
+++ b/src/dashboard/bug_email_notifier.py
@@ -4,9 +4,10 @@ from pathlib import Path
 import pandas as pd
 import smtplib
 
-# Ensure the repository root is on the Python path when executed directly.
+# Ensure the src directory is on the Python path when executed directly.
 if __package__ is None or __package__ == "":
-    sys.path.insert(0, str(Path(__file__).resolve().parents[2]))
+    project_root = Path(__file__).resolve().parents[2]
+    sys.path.insert(0, str(project_root / "src"))
 
 from db_utils import load_df, save_df, table_exists
 from email.mime.multipart import MIMEMultipart


### PR DESCRIPTION
## Summary
- update `bug_email_notifier.py` to put the `src` directory on the Python path